### PR TITLE
Changing to use symlink version of database binary file

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE-binary/SIMPLE.db'
+web: python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'


### PR DESCRIPTION
I was able to set up automatic Heroku deploys through the main branch of this repo, but it fails since it sees the SIMPLE-binary/SIMPLE.db file as empty. In this pull request, I change to using the symlink version to see if that will resolve that issue. 