### PR TITLE
Adding binary file sync for Heroku

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "SIMPLE-binary"]
-	path = SIMPLE-binary
-	url = https://github.com/SIMPLE-AstroDB/SIMPLE-binary.git

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: git submodule sync
 web: python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: git submodule sync
+release: git submodule update --init
 web: python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: wget https://github.com/SIMPLE-AstroDB/SIMPLE-binary/blob/main/SIMPLE.db?raw=true
+release: wget https://raw.githubusercontent.com/SIMPLE-AstroDB/SIMPLE-binary/main/SIMPLE.db
 web: python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-release: git submodule update --init
+release: wget https://github.com/SIMPLE-AstroDB/SIMPLE-binary/blob/main/SIMPLE.db?raw=true
 web: python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ or:
 conda create --name simple --file requirements.txt
 ```
 
-#### If you have already cloned the repo and need to add the submodule in
-First time:
+### Refresh the database
+Get a fresh copy of the database from the binary repo.
 ```bash
-git submodule update --init
+wget https://raw.githubusercontent.com/SIMPLE-AstroDB/SIMPLE-binary/main/SIMPLE.db
 ```
 
 ### Running
@@ -44,10 +44,9 @@ the [astrodbkit2](https://github.com/dr-rodriguez/AstrodbKit2) package:
 git pull --recurse-submodules upstream main
 pip install git+https://github.com/dr-rodriguez/AstrodbKit2
 ```
-Alternatively, one can update the submodule by:
+You can also get the latest copy of the SQLite database binary file with:
 ```bash
-cd SIMPLE-db
-git pull upstream main
+wget https://raw.githubusercontent.com/SIMPLE-AstroDB/SIMPLE-binary/main/SIMPLE.db
 ```
 
 For feedback, questions, or if you've found an error, 

--- a/SIMPLE.db
+++ b/SIMPLE.db
@@ -1,1 +1,0 @@
-SIMPLE-binary/SIMPLE.db


### PR DESCRIPTION
In order to deal with git submodules not always working in the Heroku deploy, I've added a wget command in the release phase to grab the latest binary file when the app gets deployed.