### PR TITLE
Aladin workaround

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 All contributors are very welcome to fork (button top right of page) the repo
 to make edits to the website code, in which case:
 ```bash
-git clone --recurse-submodules https://github.com/<your-github-username>/SIMPLE-web.git
+git clone https://github.com/<your-github-username>/SIMPLE-web.git
 cd SIMPLE-web
 git remote add origin https://github.com/<your-github-username>/SIMPLE-web.git
 git remote add upstream https://github.com/SIMPLE-AstroDB/SIMPLE-web.git
@@ -12,7 +12,7 @@ The last line is to verify the remote is set up correctly, you can then push to 
 (we advise using branches to easily isolate different changes you may be making) and pull from the upstream repo. 
 You can then create online a pull request to merge your repo into the upsteam repo after review.
 ```bash
-git pull --recurse-submodules upsteam main
+git pull upstream main
 git add <files you have changed>
 git commit -m "A good, informative commit message"
 git push origin main  # or instead of main, a different branch

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ interactive as possible.
 To run the application locally, clone the application repo and move into it with:
 
 ```bash
-git clone --recurse-submodules https://github.com/SIMPLE-AstroDB/SIMPLE-web.git
+git clone https://github.com/SIMPLE-AstroDB/SIMPLE-web.git
 cd SIMPLE-web
 ```
 
@@ -41,7 +41,7 @@ If you have changed either the host or port with system arguments, use those ins
 We also recommend keeping up to date with the repo changes, and most importantly, 
 the [astrodbkit2](https://github.com/dr-rodriguez/AstrodbKit2) package:
 ```bash
-git pull --recurse-submodules upstream main
+git pull
 pip install git+https://github.com/dr-rodriguez/AstrodbKit2
 ```
 You can also get the latest copy of the SQLite database binary file with:

--- a/simple_app/templates/solo_result.html
+++ b/simple_app/templates/solo_result.html
@@ -51,7 +51,7 @@
                 src="https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js" charset="utf-8"></script>
         <script type="text/javascript">
             var aladin = A.aladin('#aladin-lite-div',
-                {survey: "P/2MASS/J", fov:1/120,
+                {survey: "P/2MASS/color", fov:1/120,
                     target: "{{ everything.ra }} {{ everything.dec }}"});
         </script>
     </div>

--- a/simple_app/templates/solo_result.html
+++ b/simple_app/templates/solo_result.html
@@ -51,7 +51,7 @@
                 src="https://aladin.u-strasbg.fr/AladinLite/api/v2/latest/aladin.min.js" charset="utf-8"></script>
         <script type="text/javascript">
             var aladin = A.aladin('#aladin-lite-div',
-                {survey: "P/PanSTARRS/DR1/color/z/zg/g", fov:1/120,
+                {survey: "P/2MASS/J", fov:1/120,
                     target: "{{ everything.ra }} {{ everything.dec }}"});
         </script>
     </div>


### PR DESCRIPTION
There is a problem with some out-of-region surveys (e.g. Pan-STARRS), workaround for this is to default to 2MASS colour. A user is then free to play with other surveys.
Works in most recent heroku build.
Also minor documentation updates relating to the removed submodules bits.