### PR TITLE
Ensure wget clobbers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: wget https://raw.githubusercontent.com/SIMPLE-AstroDB/SIMPLE-binary/main/SIMPLE.db && python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'
+web: wget -O SIMPLE.db https://raw.githubusercontent.com/SIMPLE-AstroDB/SIMPLE-binary/main/SIMPLE.db && python simple_app/app_simple.py -p $PORT -i '0.0.0.0' -f 'SIMPLE.db'


### PR DESCRIPTION
I noticed when running this locally that wget likes to append the filenames with numbers; this edited command ensures it overwrites the existing SIMPLE.db file.  
The application was sitting on a 503 error when I checked after forcing the binary re-generation -- I think it's related