### PR TITLE
Adding container details for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+	"name": "Python 3",
+	"image": "mcr.microsoft.com/devcontainers/python:3.8",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "none"
+		}
+	},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip install -r requirements.txt && wget -O https://raw.githubusercontent.com/SIMPLE-AstroDB/SIMPLE-binary/main/SIMPLE.db"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
Using GitHub Codespaces allows us to run the website in development mode to work out details. Once the container fully starts up (including the wget for the binary database file), it's just a matter of running `python simple_app/app_simple.py -d` on the terminal and it should work out of the box. I walk us through how this works next time we meet.