### PR TITLE
Returning 404 on bad solo object search

### DIFF
--- a/simple_app/app_simple.py
+++ b/simple_app/app_simple.py
@@ -191,6 +191,8 @@ def solo_result(query: str):
 
     # search database for given object
     resultdict: dict = db.inventory(query)
+    if not len(resultdict):
+        abort(404, f'"{query}" does match any result in SIMPLE!')
     everything = Inventory(resultdict)
 
     # create camd and spectra plots

--- a/simple_app/templates/bad_request.html
+++ b/simple_app/templates/bad_request.html
@@ -3,9 +3,9 @@
 
 {% block content %}
 
-    <div class="container">
+    <div class="container" xmlns="http://www.w3.org/1999/html">
         <h1 class="display-2" style="text-align: center">{{ e.code|safe }}</h1>
-        <h2 class="display-3" style="text-align: center">Something went wrong!</h2>
+        <h2 class="display-3" style="text-align: center">Something went wrong:<br>{{ e.description|safe }}</h2>
         <h3 class="display-6">Please send the above error code and what you were trying to do, to the
             <a href="https://github.com/SIMPLE-AstroDB/SIMPLE-web/issues/new/choose" target="_blank">developers</a>.
         </h3>

--- a/simple_app/templates/bad_request.html
+++ b/simple_app/templates/bad_request.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 
-    <div class="container" xmlns="http://www.w3.org/1999/html">
+    <div class="container">
         <h1 class="display-2" style="text-align: center">{{ e.code|safe }}</h1>
         <h2 class="display-3" style="text-align: center">Something went wrong:<br>{{ e.description|safe }}</h2>
         <h3 class="display-6">Please send the above error code and what you were trying to do, to the


### PR DESCRIPTION
In the case something is directly searched for, via API, that doth not exist, return a 404. 
Also now passes customised message to the error handler page on website.
Assisting https://github.com/SIMPLE-AstroDB/SIMPLE-db/pull/451